### PR TITLE
Lesson14v4 fix

### DIFF
--- a/app/Storage/JsonStorage.php
+++ b/app/Storage/JsonStorage.php
@@ -7,7 +7,7 @@ use Exception;
 
 class JsonStorage
 {
-    public static function read(string $filename): object
+    public static function read(string $filename)
     {
         return json_decode(FileStorage::read($filename), false, 512, JSON_THROW_ON_ERROR);
     }

--- a/app/Storage/JsonStorage.php
+++ b/app/Storage/JsonStorage.php
@@ -9,7 +9,7 @@ class JsonStorage
 {
     public static function read(string $filename)
     {
-        return json_decode(FileStorage::read($filename), false, 512, JSON_THROW_ON_ERROR);
+        return json_decode(FileStorage::read($filename), true, 512, JSON_THROW_ON_ERROR);
     }
 
     public static function readArray(string $filename): array


### PR DESCRIPTION
Reaguje na https://github.com/jakubboucek/kirillova-skolka/pull/26#discussion_r296717305

**Problém 1:** Vzhledem k tomu, že `json_decode()` může vracet cokoliv (číslo, null, boolean, etc.), není možné striktně omezit návratovou hodnotu na `object`, ani na žádný jiný typ.

**Problém 2:** Je potřeba vždy při čtení JSON pole zapnout druhý parametr funkce `json_decode(..., true)` na `true` *([lear more](https://www.php.net/manual/en/function.json-decode.php))*. Není to „chyba“ PHP, ale vychází to z rozdílu, jak s poli pracuje PHP a JavaScript (ze kterého je JSON odvozen). JavaScript totiž rozlišuje mezi objektem a polem, ale v PHP je to trochu jinak. 